### PR TITLE
Remove node <7.0.0 requirement in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "main": "./lib/index.js",
   "engines": {
-    "node": ">=4.0.0 <7.0.0"
+    "node": ">=4.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",


### PR DESCRIPTION
This requirement breaks `yarn add` when running `node > 7.0.0` but running `yarn add --ignore-engines` works, so I'm assuming this requirement isn't really needed. Feel free to close this PR if I this is a bad assumption.

Related to issue #9 