### PR TITLE
Fix isomorphic rendering for JSS 7.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "babel-plugin-transform-es3-member-expression-literals": "^6.8.0",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
+    "cross-env": "^4.0.0",
     "es5-shim": "^4.3.1",
     "eslint": "^3.0.1",
     "eslint-config-airbnb": "^9.0.1",
@@ -55,8 +56,8 @@
     "webpack": "^1.12.2"
   },
   "dependencies": {
-    "jss": "^6.0.1",
-    "jss-preset-default": "^1.1.0",
+    "jss": "^7.1.1",
+    "jss-preset-default": "^2.0.0",
     "murmurhash-js": "^1.0.0"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-loader": "^6.2.2",
     "babel-plugin-inline-version": "^1.0.2",
     "babel-plugin-transform-es3-member-expression-literals": "^6.8.0",
+    "babel-plugin-transform-es3-property-literals": "^6.22.0",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
     "cross-env": "^4.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ export default function aphrodisiac(jss, options) {
 
     const style = rules.reduce(mergeStyles, {})
     sheet.addRule(className, style, {className})
+    sheet = sheet.deploy()
 
     return className
   }

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ export default function aphrodisiac(jss, options) {
 
   function reset() {
     sheet.detach()
-    jss.sheets.remove(sheet)
+    jss.removeStyleSheet(sheet)
     sheet = renderSheet()
   }
 


### PR DESCRIPTION
This PR bumps the built-in JSS dependency to `7.1.1` and updates the `reset` function to use the new version's API. This unbreaks server-side rendering for the most part, though the `<style>` tags being rendered into the DOM are still empty both on the server and in the client---more investigation is necessary to figure out why.